### PR TITLE
Fix PlayerCard not syncing names to all peers

### DIFF
--- a/src/lobby/player_card/player_card.gd
+++ b/src/lobby/player_card/player_card.gd
@@ -29,13 +29,15 @@ var player_name: String:
 	set = set_player_name
 
 @onready var cycle_type: Button = %CycleType
+@onready var display_line_edit: LineEdit = %DisplayLineEdit
 @onready var name_line_edit: LineEdit = %NameLineEdit
 
 
 func _ready() -> void:
 	cycle_type.disabled = not multiplayer.is_server()
 	var is_input_authority := multiplayer.get_unique_id() == input_authority
-	name_line_edit.editable = is_input_authority
+	display_line_edit.visible = not is_input_authority
+	name_line_edit.visible = is_input_authority
 	if is_input_authority:
 		name_line_edit.grab_focus()
 

--- a/src/lobby/player_card/player_card.tscn
+++ b/src/lobby/player_card/player_card.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://bapt74v2o7kig"]
+[gd_scene load_steps=8 format=3 uid="uid://bapt74v2o7kig"]
 
 [ext_resource type="Script" path="res://src/lobby/player_card/player_card.gd" id="1_aanr4"]
 [ext_resource type="Texture2D" uid="uid://c4ybyyfobhm40" path="res://assets/player_card_icons.png" id="2_77ty2"]
@@ -18,6 +18,11 @@ viewport_path = NodePath("HBoxContainer/CycleType/SubViewport")
 
 [sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_mbgbv"]
 properties/0/path = NodePath(".:frame")
+properties/0/spawn = true
+properties/0/replication_mode = 2
+
+[sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_onw1q"]
+properties/0/path = NodePath(".:text")
 properties/0/spawn = true
 properties/0/replication_mode = 2
 
@@ -59,13 +64,27 @@ replication_config = SubResource("SceneReplicationConfig_mbgbv")
 
 [node name="NameLineEdit" type="LineEdit" parent="HBoxContainer"]
 unique_name_in_owner = true
+editor_description = "A peer is given authority over this LineEdit so it can send input to the server."
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_colors/font_uneditable_color = Color(1, 1, 1, 1)
 placeholder_text = "player name"
 max_length = 20
 context_menu_enabled = false
 
+[node name="DisplayLineEdit" type="LineEdit" parent="HBoxContainer"]
+unique_name_in_owner = true
+editor_description = "The server retains authority over this LineEdit so it can send the player name to all other peers. While it's not intended to ever be editable, a LineEdit is used instead of a Label to keep things visually consistent."
+visible = false
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_colors/font_uneditable_color = Color(1, 1, 1, 1)
+placeholder_text = "player name"
+editable = false
+
+[node name="MultiplayerSynchronizer" type="MultiplayerSynchronizer" parent="HBoxContainer/DisplayLineEdit"]
+replication_config = SubResource("SceneReplicationConfig_onw1q")
+
+[connection signal="player_name_changed" from="." to="HBoxContainer/DisplayLineEdit" method="set_text"]
 [connection signal="player_type_changed" from="." to="HBoxContainer/CycleType/SubViewport/Sprite2D" method="set_frame"]
 [connection signal="pressed" from="HBoxContainer/CycleType" to="." method="cycle_player_type"]
 [connection signal="text_changed" from="HBoxContainer/NameLineEdit" to="." method="set_player_name"]


### PR DESCRIPTION
Adds a second LineEdit purely for displaying player names on all peers, which mimics the way they used to be synced.