### PR TITLE
Hide and ignore mouse when detecting Joypad input

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -24,6 +24,7 @@ SceneChanger="*res://src/autoload/scene_changer/scene_changer.tscn"
 FullscreenToggle="res://src/autoload/fullscreen_toggle/fullscreen_toggle.tscn"
 SteamCallbacks="res://src/autoload/steam_callbacks.gd"
 GlobalSounds="res://src/autoload/global_sounds/global_sounds.tscn"
+MouseHider="res://src/autoload/mouse_hider.gd"
 
 [debug]
 

--- a/src/autoload/mouse_hider.gd
+++ b/src/autoload/mouse_hider.gd
@@ -1,0 +1,17 @@
+extends Node
+
+
+const ACTIVE_MODE = Input.MOUSE_MODE_CONFINED
+const INACTIVE_MODE = Input.MOUSE_MODE_HIDDEN
+
+
+func _ready() -> void:
+	Input.set_mouse_mode(INACTIVE_MODE)
+
+
+func _input(event: InputEvent) -> void:
+	if event is InputEventMouseMotion:
+		Input.set_mouse_mode(ACTIVE_MODE)
+
+	elif event is InputEventJoypadButton or event is InputEventJoypadMotion:
+		Input.set_mouse_mode(INACTIVE_MODE)

--- a/src/controller/keyboard_and_mouse/keyboard_and_mouse.gd
+++ b/src/controller/keyboard_and_mouse/keyboard_and_mouse.gd
@@ -1,23 +1,15 @@
 extends Controller
 
 
-var _mouse_active := false
+func _process(_delta: float) -> void:
+	_look_at_mouse_if_visible()
+	if _is_mouse_visible():
+		input_handled.emit()
 
 
-func _unhandled_input(event: InputEvent) -> void:
+func _unhandled_input(_event: InputEvent) -> void:
 	move_vector = Input.get_vector("move_left", "move_right", "move_up", "move_down")
-	if event is InputEventMouseMotion:
-		_mouse_active = true
-		$Timer.start()
-
-	if _mouse_active:
-		look_vector = Vector2.from_angle(
-				global_position.angle_to_point(get_global_mouse_position())
-		)
-
-	else:
-		look_vector = Vector2.ZERO
-
+	_look_at_mouse_if_visible()
 	button_1 = Input.is_action_pressed("button_1")
 	button_2 = Input.is_action_pressed("button_2")
 
@@ -26,18 +18,24 @@ func _unhandled_input(event: InputEvent) -> void:
 
 func force_handle_input() -> void:
 	move_vector = Input.get_vector("move_left", "move_right", "move_up", "move_down")
-	if _mouse_active:
-		look_vector = Vector2.from_angle(
-				global_position.angle_to_point(get_global_mouse_position())
-		)
-
-	else:
-		look_vector = Vector2.ZERO
-
+	_look_at_mouse_if_visible()
 	button_1 = Input.is_action_pressed("button_1")
 	button_2 = Input.is_action_pressed("button_2")
 	input_handled.emit()
 
 
-func _on_timer_timeout() -> void:
-	_mouse_active = false
+func _is_mouse_visible() -> bool:
+	return not Input.get_mouse_mode() in [
+			Input.MOUSE_MODE_CONFINED_HIDDEN,
+			Input.MOUSE_MODE_HIDDEN
+	]
+
+
+func _look_at_mouse_if_visible() -> void:
+	if not _is_mouse_visible():
+		look_vector = Vector2.ZERO
+		return
+
+	look_vector = Vector2.from_angle(
+			global_position.angle_to_point(get_global_mouse_position())
+	)

--- a/src/controller/keyboard_and_mouse/keyboard_and_mouse.tscn
+++ b/src/controller/keyboard_and_mouse/keyboard_and_mouse.tscn
@@ -4,10 +4,3 @@
 
 [node name="KeyboardAndMouse" type="Node2D"]
 script = ExtResource("1_vscdr")
-
-[node name="Timer" type="Timer" parent="."]
-process_callback = 0
-wait_time = 3.0
-one_shot = true
-
-[connection signal="timeout" from="Timer" to="." method="_on_timer_timeout"]


### PR DESCRIPTION
Immediately hides and ignores the mouse when detecting joypad input. Mouse reappears and affects player input again when it moves, and it will remain active until hidden by joypad input (instead of the old 3-second idle timeout).