### PR TITLE
Change pulse animation to remove red only

### DIFF
--- a/src/animation_libaries/canvas_item.tres
+++ b/src/animation_libaries/canvas_item.tres
@@ -45,7 +45,7 @@ tracks/0/keys = {
 "times": PackedFloat32Array(0, 0.2),
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
-"values": [Color(1, 1, 1, 1), Color(1, 0, 0, 1)]
+"values": [Color(1, 1, 1, 1), Color(0, 1, 1, 1)]
 }
 
 [resource]


### PR DESCRIPTION
Changes the animation used for ghost panic to be much more obvious with the ghost's red sprite.