### PR TITLE
Revert "Fix player cards not auto-setting initial type"

### DIFF
--- a/src/lobby/player_card/player_card.gd
+++ b/src/lobby/player_card/player_card.gd
@@ -40,11 +40,10 @@ func _ready() -> void:
 	if is_input_authority:
 		name_line_edit.grab_focus()
 
-	auto_set_player_type()
 	set_player_name(str(_get_autoload_peer_name(input_authority)))
 
 
-func auto_set_player_type(caller: Node = null) -> void:
+func auto_set_player_type(caller: Node) -> void:
 	if caller == self:
 		return
 


### PR DESCRIPTION
Reverts zibetnu/haunting-hijinx#57

The core of the issue lies with PeerData, not PlayerCard. Reverting this hasty merge in favor of a better fix.